### PR TITLE
MFLP: Backend setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+# -----------------------
+# Node.js & React Monorepo .gitignore
+# -----------------------
+
+# Node dependencies
+node_modules/
+**/node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Build outputs (frontend & backend)
+build/
+dist/
+.next/
+out/
+coverage/
+
+# Environment files
+.env
+.env.* 
+!.env.example
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# IDE-specific files
+.vscode/
+.idea/
+*.swp
+
+# Docker
+.docker/
+docker-compose.override.yml
+
+# Package managers
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Test coverage
+coverage/
+*.lcov
+
+# Temporary files
+tmp/
+temp/
+.cache/
+.parcel-cache/
+*.pid
+*.seed
+*.pid.lock
+
+# Storybook
+.storybook-out/
+storybook-static/
+
+# Misc
+*.tgz
+*.tar.gz
+*.log
+*.bak
+*.orig
+
+# TypeScript
+*.tsbuildinfo

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@app/server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "cors": "2.8.5",
+    "express": "4.19.2",
+    "morgan": "1.10.0",
+    "nanoid": "5.0.7",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "2.8.17",
+    "@types/express": "4.17.21",
+    "@types/morgan": "1.9.9",
+    "@types/node": "20.14.9",
+    "tsx": "4.16.2",
+    "typescript": "5.6.2"
+  },
+  "engines": {
+    "node": "22.x"
+  }
+}
+

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,0 +1,39 @@
+import express, {
+  type NextFunction,
+  type Application,
+  type Request,
+  type Response,
+} from "express";
+import cors from "cors";
+import morgan from "morgan";
+
+const app: Application = express();
+
+const corsOrigin = process.env.CORS_ORIGIN ?? "*";
+const API_VERSION = "v1" as const;
+type TApiVersion = typeof API_VERSION;
+
+function setApiVersion(version: TApiVersion) {
+  return (_req: Request, res: Response, next: NextFunction): void => {
+    res.setHeader("X-API-VERSION", version);
+    next();
+  };
+}
+
+app.use(cors({ origin: corsOrigin }));
+app.use(express.json({ limit: "1mb" }));
+app.use(morgan("dev"));
+
+app.get("/healthz", (_req: Request, res) => {
+  res.json({ ok: true as const, ts: new Date().toISOString() });
+});
+
+app.use("/api/v1", setApiVersion(API_VERSION));
+
+app.use((_req: Request, res: Response) =>
+  res
+    .status(404)
+    .json({ error: "NOT_FOUND" as const, message: "Route not found" })
+);
+
+export { app };

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,0 +1,20 @@
+import { app } from "./app";
+
+const port = Number(process.env.PORT ?? 3001);
+
+const server = app.listen(port, () => {
+  console.log(`Server listening on port:${port}`);
+});
+
+function shutdown(signal: string) {
+  // eslint-disable-next-line no-console
+  console.log(`Server received ${signal}, closing...`);
+  server.close(() => {
+    // eslint-disable-next-line no-console
+    console.log("Server closed. Bye!");
+    process.exit(0);
+  });
+}
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "veritone-shopping-list-monorepo",
+  "workspaces": [
+    "apps/*"
+  ],
+  "scripts": {
+    "dev": "docker compose up --build",
+    "down": "docker compose down -v",
+    "typecheck": "tsc -b"
+  },
+  "devDependencies": {
+    "typescript": "5.6.2",
+    "rimraf": "6.0.1"
+  },
+  "engines": {
+    "node": "22.x"
+  },
+  "packageManager": "npm@10.9.2"
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler", // friendlier resolution for modern ESM (lets you use explicit ".js" extensions in TS)
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true, // smoother CJS/ESM interop for defs like "express"
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true, // speeds up builds by not type-checking node_modules
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
# What's in this PR
- This PR introduces the initial Express server setup with essential middleware, a health check endpoint, and API versioning headers. It lays the foundation for handling future API routes under /api/v1.
  - **Server Initialization**
    - Created an express application instance.
    - Added `express.json` with a 1MB payload size limit.
  - **Middleware**
    - Integrated CORS with configurable origin via `CORS_ORIGIN` environment variable (defaults to `*`).
    - Added **morgan** in `dev` mode for request logging. 
    - Implemented middle to inject `X-API-VERSION` header into all `/api/v1` responses.
  - **Routes**
    - Added `GET /healthz` endpoint to verify server health.
    - Placeholder for future versioned routes mounted under `/api/v1`
  - **Error Handling**
    - Global 404 handler returning "NOT_FOUND"