### PR TITLE
Feature/backend items crud

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -6,7 +6,7 @@ import express, {
 } from "express";
 import cors from "cors";
 import morgan from "morgan";
-
+import { errorHandler } from "./middleware/errorHandler";
 import { itemsRoutes } from "./modules/items/routes";
 
 const API_VERSION = "v1" as const;
@@ -40,5 +40,6 @@ app.use((_req: Request, res: Response) =>
     .status(404)
     .json({ error: "NOT_FOUND" as const, message: "Route not found" })
 );
+app.use(errorHandler);
 
 export { app };

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -7,18 +7,20 @@ import express, {
 import cors from "cors";
 import morgan from "morgan";
 
-const app: Application = express();
+import { itemsRoutes } from "./modules/items/routes";
 
-const corsOrigin = process.env.CORS_ORIGIN ?? "*";
 const API_VERSION = "v1" as const;
-type TApiVersion = typeof API_VERSION;
 
-function setApiVersion(version: TApiVersion) {
+function setApiVersion(version: typeof API_VERSION) {
   return (_req: Request, res: Response, next: NextFunction): void => {
     res.setHeader("X-API-VERSION", version);
     next();
   };
 }
+
+const app: Application = express();
+
+const corsOrigin = process.env.CORS_ORIGIN ?? "*";
 
 app.use(cors({ origin: corsOrigin }));
 app.use(express.json({ limit: "1mb" }));
@@ -29,6 +31,9 @@ app.get("/healthz", (_req: Request, res) => {
 });
 
 app.use("/api/v1", setApiVersion(API_VERSION));
+
+// Mount MVP CRUD at /api/v1/items
+app.use("/api/v1/items", itemsRoutes);
 
 app.use((_req: Request, res: Response) =>
   res

--- a/apps/server/src/middleware/errorHandler.ts
+++ b/apps/server/src/middleware/errorHandler.ts
@@ -1,0 +1,30 @@
+import type { NextFunction, Request, Response } from "express";
+import { ZodError } from "zod";
+
+type ErrorBody =
+  | { error: "BAD_REQUEST"; message: string }
+  | { error: "NOT_FOUND"; message: string }
+  | { error: "ERROR" | "INTERNAL"; message: string };
+
+export const errorHandler = (
+  err: unknown,
+  _req: Request,
+  res: Response<ErrorBody>,
+  _next: NextFunction
+) => {
+  if (err instanceof ZodError) {
+    res
+      .status(400)
+      .json({ error: "BAD_REQUEST", message: "Validation failed" });
+    return;
+  }
+
+  const status = (err as { status?: number } | undefined)?.status ?? 500;
+  const message =
+    (err as { message?: string } | undefined)?.message ??
+    "Internal Server Error";
+
+  res
+    .status(status)
+    .json({ error: status === 500 ? "INTERNAL" : "ERROR", message });
+};

--- a/apps/server/src/modules/items/controller.ts
+++ b/apps/server/src/modules/items/controller.ts
@@ -1,0 +1,121 @@
+import type { Request, Response } from "express";
+import { ItemsService } from "./service";
+import {
+  ItemCreateSchema,
+  ItemUpdateSchema,
+  ItemIdSchema,
+  type ItemCreateInput,
+  type ItemUpdateInput,
+  type ItemIdInput,
+} from "./schemas.js";
+
+export const ItemsController = {
+  /** GET /api/v1/items — list all (MVP) */
+  async list(_req: Request, res: Response): Promise<void> {
+    const items = await ItemsService.listAll();
+    res.json({ items, count: items.length });
+  },
+
+  /** GET /api/v1/items/:id */
+  async get(req: Request<ItemIdInput>, res: Response): Promise<void> {
+    const params = ItemIdSchema.safeParse(req.params);
+    if (!params.success) {
+      res
+        .status(400)
+        .json({
+          error: "BAD_REQUEST" as const,
+          message: "Invalid id",
+          issues: params.error.issues,
+        });
+      return;
+    }
+    const item = await ItemsService.get(params.data.id);
+    if (!item) {
+      res
+        .status(404)
+        .json({ error: "NOT_FOUND" as const, message: "Item not found" });
+      return;
+    }
+    res.json(item);
+  },
+
+  /** POST /api/v1/items */
+  async create(
+    req: Request<unknown, unknown, ItemCreateInput>,
+    res: Response
+  ): Promise<void> {
+    const parsed = ItemCreateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res
+        .status(400)
+        .json({
+          error: "BAD_REQUEST" as const,
+          message: "Validation failed",
+          issues: parsed.error.issues,
+        });
+      return;
+    }
+    const created = await ItemsService.create(parsed.data);
+    res.status(201).json(created);
+  },
+
+  /** PATCH /api/v1/items/:id */
+  async update(
+    req: Request<ItemIdInput, unknown, ItemUpdateInput>,
+    res: Response
+  ): Promise<void> {
+    const params = ItemIdSchema.safeParse(req.params);
+    if (!params.success) {
+      res
+        .status(400)
+        .json({
+          error: "BAD_REQUEST" as const,
+          message: "Invalid id",
+          issues: params.error.issues,
+        });
+      return;
+    }
+    const patch = ItemUpdateSchema.safeParse(req.body);
+    if (!patch.success) {
+      res
+        .status(400)
+        .json({
+          error: "BAD_REQUEST" as const,
+          message: "Validation failed",
+          issues: patch.error.issues,
+        });
+      return;
+    }
+    const updated = await ItemsService.update(params.data.id, patch.data);
+    if (!updated) {
+      res
+        .status(404)
+        .json({ error: "NOT_FOUND" as const, message: "Item not found" });
+      return;
+    }
+    res.json(updated);
+  },
+
+  /** DELETE /api/v1/items/:id */
+  async remove(req: Request<ItemIdInput>, res: Response): Promise<void> {
+    const params = ItemIdSchema.safeParse(req.params);
+    if (!params.success) {
+      res
+        .status(400)
+        .json({
+          error: "BAD_REQUEST" as const,
+          message: "Invalid id",
+          issues: params.error.issues,
+        });
+      return;
+    }
+    const ok = await ItemsService.delete(params.data.id);
+    if (!ok) {
+      res
+        .status(404)
+        .json({ error: "NOT_FOUND" as const, message: "Item not found" });
+      return;
+    }
+    res.status(204).send();
+  },
+} as const;

--- a/apps/server/src/modules/items/domain.ts
+++ b/apps/server/src/modules/items/domain.ts
@@ -1,0 +1,20 @@
+// NOTE: Separating makes it explicit that this string is an "identifier" for an item, not just any string 
+export type ItemId = string;
+
+export interface Item {
+  id: ItemId;
+  name: string;
+  description?: string;
+  quantity: number;
+  purchased: boolean;
+  createdAt: string; // ISO
+  updatedAt: string; // ISO
+}
+
+export type ItemCreate = {
+  name: string;
+  description?: string;
+  quantity?: number;
+};
+
+export type ItemUpdate = Partial<Pick<Item, "name" | "description" | "quantity" | "purchased">>;

--- a/apps/server/src/modules/items/repo.inMemory.ts
+++ b/apps/server/src/modules/items/repo.inMemory.ts
@@ -1,0 +1,64 @@
+// NOTE: Provides repository implementation prior to connecting to the Postgres database
+import { nanoid } from "nanoid";
+import type { Item, ItemCreate, ItemId, ItemUpdate } from "./domain.js";
+import type { ItemsRepo } from "./repo.js";
+
+const nowISO = (): string => new Date().toISOString();
+
+export class InMemoryItemsRepo implements ItemsRepo {
+  private readonly items = new Map<ItemId, Item>();
+
+  async listAll(): Promise<Item[]> {
+    // MVP: return everything (creation-desc to keep newest first)
+    return Array.from(this.items.values()).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  async get(id: ItemId): Promise<Item | undefined> {
+    return this.items.get(id);
+  }
+
+  async create(input: ItemCreate): Promise<Item> {
+    const id = nanoid();
+    const createdAt = nowISO();
+    const item: Item = {
+      id,
+      name: input.name,
+      description: input.description?.trim() || undefined,
+      quantity: Number(input.quantity ?? 1),
+      purchased: false,
+      createdAt,
+      updatedAt: createdAt,
+    };
+    this.items.set(id, item);
+    return item;
+  }
+
+  async update(id: ItemId, patch: ItemUpdate): Promise<Item | undefined> {
+    const current = this.items.get(id);
+    if (!current) return undefined;
+
+    const next: Item = {
+      ...current,
+      name: patch.name?.trim() ?? current.name,
+      description:
+        patch.description !== undefined ? patch.description.trim() || undefined : current.description,
+      quantity: patch.quantity !== undefined ? Math.max(1, Number(patch.quantity)) : current.quantity,
+      purchased: patch.purchased ?? current.purchased,
+      updatedAt: nowISO(),
+    };
+
+    this.items.set(id, next);
+    return next;
+  }
+
+  async delete(id: ItemId): Promise<boolean> {
+    return this.items.delete(id);
+  }
+}
+
+// Singleton (simple for MVP)
+export const itemsRepo = new InMemoryItemsRepo();
+
+// Seed a couple for quick manual checks
+void itemsRepo.create({ name: "Apples", description: "Honey Crisp", quantity: 4 });
+void itemsRepo.create({ name: "Eggs", description: "Free-range", quantity: 12 });

--- a/apps/server/src/modules/items/repo.ts
+++ b/apps/server/src/modules/items/repo.ts
@@ -1,0 +1,12 @@
+// NOTE: Domain-Driven Design - Repository pattern
+// A layer whose job is to talk to the data source (database/API) and give back domain objects
+// Repo acts as a boundary between domain (business rules, types) and infrastructure (Postgres, Prisma, REST APIs)
+import type { Item, ItemCreate, ItemId, ItemUpdate } from "./domain.js";
+
+export interface ItemsRepo {
+  listAll(): Promise<Item[]>;
+  get(id: ItemId): Promise<Item | undefined>;
+  create(input: ItemCreate): Promise<Item>;
+  update(id: ItemId, patch: ItemUpdate): Promise<Item | undefined>;
+  delete(id: ItemId): Promise<boolean>;
+}

--- a/apps/server/src/modules/items/routes.ts
+++ b/apps/server/src/modules/items/routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { ItemsController } from "./controller.js";
+
+export const itemsRoutes = Router();
+
+// MVP CRUD — no query params on list
+itemsRoutes.get("/", ItemsController.list);
+itemsRoutes.post("/", ItemsController.create);
+itemsRoutes.get("/:id", ItemsController.get);
+itemsRoutes.patch("/:id", ItemsController.update);
+itemsRoutes.delete("/:id", ItemsController.remove);

--- a/apps/server/src/modules/items/schemas.ts
+++ b/apps/server/src/modules/items/schemas.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const ItemIdSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const ItemCreateSchema = z.object({
+  name: z.string().min(1, "name is required").max(120),
+  description: z.string().max(500).optional(),
+  quantity: z.coerce.number().int().min(1).max(999).optional(),
+});
+
+export const ItemUpdateSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  description: z
+    .string()
+    .max(500)
+    .optional()
+    .nullable()
+    .transform((v) => v ?? undefined),
+  quantity: z.coerce.number().int().min(1).max(999).optional(),
+  purchased: z.boolean().optional(),
+});
+
+export type ItemIdInput = z.infer<typeof ItemIdSchema>;
+export type ItemCreateInput = z.infer<typeof ItemCreateSchema>;
+export type ItemUpdateInput = z.infer<typeof ItemUpdateSchema>;

--- a/apps/server/src/modules/items/service.ts
+++ b/apps/server/src/modules/items/service.ts
@@ -1,0 +1,20 @@
+import type { Item, ItemCreate, ItemId, ItemUpdate } from "./domain.js";
+import { itemsRepo } from "./repo.inMemory.js";
+
+export const ItemsService = {
+  async listAll(): Promise<Item[]> {
+    return itemsRepo.listAll();
+  },
+  async get(id: ItemId): Promise<Item | undefined> {
+    return itemsRepo.get(id);
+  },
+  async create(input: ItemCreate): Promise<Item> {
+    return itemsRepo.create(input);
+  },
+  async update(id: ItemId, patch: ItemUpdate): Promise<Item | undefined> {
+    return itemsRepo.update(id, patch);
+  },
+  async delete(id: ItemId): Promise<boolean> {
+    return itemsRepo.delete(id);
+  },
+} as const;

--- a/apps/server/src/utils/asyncHandler.ts
+++ b/apps/server/src/utils/asyncHandler.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from "express";
+
+/**
+ * Ensures any thrown error or rejected Promise in an async handler
+ * is forwarded to Express's error pipeline (next(err)).
+ */
+export function asyncHandler<
+  P = any,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = any
+>(
+  fn: RequestHandler<P, ResBody, ReqBody, ReqQuery>
+): RequestHandler<P, ResBody, ReqBody, ReqQuery> {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
# What's in this PR
- Add in-memory repo and MVP items CRUD. Introduces `InMemoryItemsRepo` implementing `ItemsRepo` to unblock development before Postgres.
- Normalizes fiels (trim strings, limit quanity) and timestamps(`createdAt/updatedAt` ISO).

### Endpoints (MVP)
- `GET /api/v1/items` - list all items
- `GET /api/v1/items/:id` - get item
- `POST /api/v1/items` - create item
- `PATCH /api/v1/items/:id` - update item
- `DELETE /api/v1/items/:id` - delete item

### How to test
```
# list
curl -s http://localhost:3001/api/v1/items | jq
# create
curl -s -X POST http://localhost:3001/api/v1/items \
  -H "Content-Type: application/json" \
  -d '{"name":"Milk","description":"2%","quantity":1}' | jq
# read
curl -s http://localhost:3001/api/v1/items/<ID> | jq
# update
curl -s -X PATCH http://localhost:3001/api/v1/items/<ID> \
  -H "Content-Type: application/json" \
  -d '{"purchased":true,"quantity":2}' | jq
# delete
curl -i -X DELETE http://localhost:3001/api/v1/items/<ID>

```