### PR TITLE
Chore/refactor global drawer

### DIFF
--- a/apps/web/src/components/ItemForm/ItemForm.spec.tsx
+++ b/apps/web/src/components/ItemForm/ItemForm.spec.tsx
@@ -1,0 +1,240 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ItemForm from "./";
+
+jest.mock("@app/shared", () => {
+  const { z } = require("zod");
+  const ItemSchema = z.object({
+    id: z.string().optional(),
+    itemName: z.string().trim().min(1, "Item name is required."),
+    description: z.string().optional(),
+    quantity: z.number().int().positive().optional(),
+    purchased: z.boolean().optional(),
+    createdAt: z.any().optional(),
+    updatedAt: z.any().optional(),
+  });
+  return {
+    ItemSchema,
+  };
+});
+
+jest.mock("../../constants/drawer", () => ({
+  DEFAULT_ITEM: {
+    id: "",
+    itemName: "",
+    description: "",
+    quantity: undefined,
+    purchased: false,
+    createdAt: undefined,
+    updatedAt: undefined,
+  },
+  MAX_DESCRIPTION: 200,
+}));
+
+jest.mock("../../components/ui/button", () => ({
+  Button: (props: any) => <button {...props} />,
+}));
+
+jest.mock("../../components/ui/checkbox", () => ({
+  Checkbox: ({ onCheckedChange, checked, ...rest }: any) => (
+    <input
+      type="checkbox"
+      checked={!!checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+      {...rest}
+    />
+  ),
+}));
+
+jest.mock("../../components/ui/drawer", () => ({
+  DrawerClose: ({ asChild, children }: any) =>
+    asChild ? children : <button>{children}</button>,
+  DrawerDescription: ({ className, children }: any) => (
+    <p data-testid="drawer-description" className={className}>
+      {children}
+    </p>
+  ),
+  DrawerFooter: ({ className, children }: any) => (
+    <div data-testid="drawer-footer" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("../../components/ui/input", () => {
+  const React = require("react");
+  return {
+    Input: React.forwardRef(function InputMock(
+      props: any,
+      ref: React.ForwardedRef<HTMLInputElement>
+    ) {
+      return <input ref={ref} {...props} />;
+    }),
+  };
+});
+
+jest.mock("../../components/ui/textarea", () => {
+  const React = require("react");
+  return {
+    Textarea: React.forwardRef(function TextareaMock(
+      props: any,
+      ref: React.ForwardedRef<HTMLTextAreaElement>
+    ) {
+      return <textarea ref={ref} {...props} />;
+    }),
+  };
+});
+
+jest.mock("../../components/ui/select", () => ({
+  Select: ({
+    value,
+    onClick,
+    onOpenChange,
+  }: {
+    value?: number;
+    onClick: (v: number) => void;
+    onOpenChange?: (v: boolean) => void;
+  }) => (
+    <div>
+      <div data-testid="select-value">{value ?? ""}</div>
+      <button
+        type="button"
+        data-testid="select-1"
+        onClick={() => {
+          onClick(1);
+          onOpenChange?.(false);
+        }}
+      >
+        Select 1
+      </button>
+      <button
+        type="button"
+        data-testid="select-3"
+        onClick={() => {
+          onClick(3);
+          onOpenChange?.(false);
+        }}
+      >
+        Select 3
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("../../utils", () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(" "),
+}));
+
+const baseDefaultValues = {
+  id: "",
+  itemName: "",
+  description: "",
+  quantity: undefined,
+  purchased: false,
+  createdAt: undefined,
+  updatedAt: undefined,
+};
+
+function renderForm(
+  overrides?: Partial<React.ComponentProps<typeof ItemForm>>
+) {
+  const props: React.ComponentProps<typeof ItemForm> = {
+    description: "Add your new item below",
+    selectOpen: false,
+    setSelectOpen: () => {},
+    onClose: () => {},
+    type: "create",
+    defaultValues: baseDefaultValues,
+    onConfirm: () => {},
+    ...overrides,
+  };
+  return render(<ItemForm {...props} />);
+}
+
+const getSubmitBtn = () =>
+  screen.getByRole("button", { name: /Add Task|Save Item|Saving...|Updating.../i });
+
+/* ───────────── Tests ───────────── */
+
+describe("ItemForm", () => {
+  it("renders and shows provided description", () => {
+    renderForm({ description: "Hello description" });
+    expect(screen.getByTestId("drawer-description")).toHaveTextContent(
+      "Hello description"
+    );
+  });
+
+  it("create mode: requires itemName, allows selecting quantity, normalizes defaults, calls onConfirm and onClose", async () => {
+    const onConfirm = jest.fn();
+    const onClose = jest.fn();
+
+    renderForm({
+      type: "create",
+      onConfirm,
+      onClose,
+      defaultValues: baseDefaultValues,
+    });
+
+    const submit = getSubmitBtn();
+    expect(submit).toBeDisabled();
+
+    const name = screen.getByPlaceholderText("Item Name");
+    fireEvent.change(name, { target: { name: "itemName", value: "Milk" } });
+
+    fireEvent.click(screen.getByTestId("select-3"));
+    expect(screen.getByTestId("select-value")).toHaveTextContent("3");
+
+    await waitFor(() => expect(submit).not.toBeDisabled());
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    const payload = onConfirm.mock.calls[0][0];
+
+    expect(payload).toMatchObject({
+      itemName: "Milk",
+      description: "",
+      quantity: 3,
+      purchased: false,
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("update mode: shows Purchased checkbox and requires dirty state before submit", async () => {
+    const onConfirm = jest.fn();
+
+    renderForm({
+      type: "update",
+      onConfirm,
+      defaultValues: {
+        ...baseDefaultValues,
+        id: "abc",
+        itemName: "Bread",
+        description: "Whole",
+        quantity: 2,
+        purchased: false,
+      },
+    });
+
+    const purchased = screen.getByLabelText("Purchased");
+    expect(purchased).toBeInTheDocument();
+
+    const submit = getSubmitBtn();
+    expect(submit).toBeDisabled();
+
+    fireEvent.click(purchased);
+
+    await waitFor(() => expect(submit).not.toBeDisabled());
+
+    fireEvent.click(submit);
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+
+    const payload = onConfirm.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      itemName: "Bread",
+      description: "Whole",
+      quantity: 2,
+      purchased: true,
+    });
+  });
+});

--- a/apps/web/src/components/ItemForm/index.tsx
+++ b/apps/web/src/components/ItemForm/index.tsx
@@ -1,0 +1,243 @@
+import { FC } from "react";
+import { useForm, Controller, SubmitHandler } from "react-hook-form";
+import {
+  ItemDTO,
+  ItemSchema,
+  type ItemFormInput,
+  type ItemFormOutput,
+} from "@app/shared";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { DEFAULT_ITEM, MAX_DESCRIPTION } from "../../constants/drawer";
+import { Button } from "../../components/ui/button";
+import { Checkbox } from "../../components/ui/checkbox";
+import {
+  DrawerClose,
+  DrawerDescription,
+  DrawerFooter,
+} from "../../components/ui/drawer";
+import { Input } from "../../components/ui/input";
+import { Select } from "../../components/ui/select";
+import { Textarea } from "../../components/ui/textarea";
+import { GlobalDrawerType } from '../../types/drawer';
+import { cn } from "../../utils";
+
+interface ItemFormProps {
+  description: string;
+  descriptionTextClassName?: string;
+  selectOpen: boolean;
+  setSelectOpen: (open: boolean) => void;
+  onClose: () => void;
+  type?: GlobalDrawerType;
+  defaultValues: ItemDTO;
+  onConfirm?: (data: ItemFormOutput) => Promise<void> | void;
+}
+
+const ItemForm: FC<ItemFormProps> = ({
+  type,
+  description,
+  descriptionTextClassName,
+  defaultValues = DEFAULT_ITEM,
+  onConfirm,
+  onClose,
+  selectOpen,
+  setSelectOpen,
+}) => {
+  const isUpdateMode = type === "update";
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors, isSubmitting, isValid, isDirty },
+    watch,
+    reset,
+  } = useForm<ItemFormInput, any, ItemFormOutput>({
+    resolver: zodResolver(ItemSchema),
+    mode: "onChange",
+    defaultValues,
+  });
+
+  const descriptionValue = watch("description") ?? "";
+  const quantityValue = watch("quantity") as number | undefined;
+
+  const clearForm = () => {
+    if (isUpdateMode) {
+      return reset({
+        ...defaultValues,
+        description: defaultValues.description ?? "",
+      });
+    }
+    return reset(DEFAULT_ITEM);
+  };
+
+  const onSubmit: SubmitHandler<ItemFormOutput> = async (data) => {
+    clearForm();
+    onClose();
+    onConfirm?.({
+      ...data,
+      quantity: data.quantity ?? 1,
+      purchased: data.purchased ?? false,
+    });
+  };
+
+  return (
+    <>
+      <div className="pl-[30px] pt-7 pr-6 flex-1">
+        <div className="flex flex-col font-nunito font-normal mb-4">
+          <h2 className="text-lg leading-6 text-primaryFont">Add an Item</h2>
+          <div className="flex items-center justify-between">
+            <DrawerDescription
+              className={cn(
+                "text-base leading-[22px] text-secondaryFont mt-2",
+                descriptionTextClassName
+              )}
+            >
+              {description}
+            </DrawerDescription>
+            {isDirty && (
+              <button
+                data-testid="clear-form-btn"
+                onClick={clearForm}
+                className="font-medium text-xs hover:opacity-80 text-primaryFont"
+              >
+                Clear Form
+              </button>
+            )}
+          </div>
+        </div>
+
+        <form
+          id="item-form"
+          className="flex flex-col gap-4"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <div>
+            <Input
+              id="item-name"
+              placeholder="Item Name"
+              {...register("itemName")}
+            />
+            {errors.itemName && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.itemName.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <div className="relative h-[140px]">
+              <Textarea
+                id="item-description"
+                placeholder="Description"
+                {...register("description")}
+              />
+              <span
+                className={cn(
+                  "text-xs absolute bottom-3 right-3",
+                  descriptionValue.length > MAX_DESCRIPTION
+                    ? "text-red-600"
+                    : "text-secondaryFont"
+                )}
+                aria-live="polite"
+              >
+                {descriptionValue.length}/{MAX_DESCRIPTION}
+              </span>
+            </div>
+            {errors.description && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <Controller
+              control={control}
+              name="quantity"
+              render={({ field }) => (
+                <Select
+                  open={selectOpen}
+                  onOpenChange={setSelectOpen}
+                  onClick={(value: number) => {
+                    field.onChange(value);
+                    setSelectOpen(false);
+                  }}
+                  value={quantityValue}
+                />
+              )}
+            />
+            {errors.quantity && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.quantity.message}
+              </p>
+            )}
+          </div>
+
+          {isUpdateMode && (
+            <div className="flex items-center justify-between mt-4 z-[1]">
+              <Controller
+                control={control}
+                name="purchased"
+                render={({ field: { value, onChange } }) => (
+                  <div className="flex gap-4 h-6 items-center">
+                    <Checkbox
+                      id="item-purchased"
+                      name="item-purchased"
+                      checked={value}
+                      onCheckedChange={(checked) => onChange(Boolean(checked))}
+                      aria-invalid={!!errors.purchased || undefined}
+                    />
+                    <label
+                      htmlFor="item-purchased"
+                      className={cn(
+                        "text-placeholderGray text-base leading-[22px] font-nunito",
+                        value && "text-primaryFont"
+                      )}
+                    >
+                      Purchased
+                    </label>
+                  </div>
+                )}
+              />
+            </div>
+          )}
+        </form>
+      </div>
+
+      <DrawerFooter className="bg-white w-full flex">
+        <div className="flex gap-4 w-full justify-end pr-2 font-nunito mb-2">
+          <DrawerClose asChild>
+            <Button
+              variant="secondary"
+              className="h-9 font-normal hover:opacity-80"
+            >
+              Cancel
+            </Button>
+          </DrawerClose>
+
+          <Button
+            variant="default"
+            className={cn(
+              "h-9 font-normal w-[85px]",
+              isUpdateMode && "w-[100px]"
+            )}
+            form="item-form"
+            type="submit"
+            disabled={isSubmitting || !isValid || (!isDirty && isUpdateMode)}
+          >
+            {isSubmitting
+              ? isUpdateMode
+                ? "Updating..."
+                : "Saving..."
+              : isUpdateMode
+              ? "Save Item"
+              : "Add Task"}
+          </Button>
+        </div>
+      </DrawerFooter>
+    </>
+  );
+};
+
+export default ItemForm;

--- a/apps/web/src/components/ItemForm/index.tsx
+++ b/apps/web/src/components/ItemForm/index.tsx
@@ -130,6 +130,7 @@ const ItemForm: FC<ItemFormProps> = ({
               <Textarea
                 id="item-description"
                 placeholder="Description"
+                className="resize-none"
                 {...register("description")}
               />
               <span

--- a/apps/web/src/providers/GlobalDrawerProvider.tsx
+++ b/apps/web/src/providers/GlobalDrawerProvider.tsx
@@ -1,34 +1,15 @@
-import { FC, ReactNode, createContext, useEffect, useState } from "react";
-import { useForm, Controller, SubmitHandler } from "react-hook-form";
-import {
-  ItemSchema,
-  type ItemFormInput,
-  type ItemFormOutput,
-} from "@app/shared";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { FC, ReactNode, createContext, useMemo, useState } from "react";
 
-import {
-  DEFAULT_GLOBAL_DRAWER_PROPS,
-  DEFAULT_ITEM,
-  MAX_DESCRIPTION,
-} from "../constants/drawer";
+import ItemForm from "../components/ItemForm";
+import { DEFAULT_GLOBAL_DRAWER_PROPS } from "../constants/drawer";
 import HideIcon from "../components/Icons/HideIcon";
-import { Button } from "../components/ui/button";
-import { Checkbox } from "../components/ui/checkbox";
 import {
   Drawer,
-  DrawerClose,
   DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
   DrawerHeader,
   DrawerTitle,
 } from "../components/ui/drawer";
-import { Input } from "../components/ui/input";
-import { Select } from "../components/ui/select";
-import { Textarea } from "../components/ui/textarea";
 import { GlobalDrawerContextType, GlobalDrawerProps } from "../types/drawer";
-import { cn } from "../utils";
 
 export const GlobalDrawerContext =
   createContext<GlobalDrawerContextType | null>(null);
@@ -52,59 +33,11 @@ const GlobalDrawerProvider: FC<GlobalDrawerProviderProps> = ({ children }) => {
     onConfirm,
   } = drawerProps;
 
-  const isUpdateMode = type === "update";
-
-  const {
-    register,
-    control,
-    handleSubmit,
-    formState: { errors, isSubmitting, isValid, isDirty },
-    watch,
-    reset,
-  } = useForm<ItemFormInput, any, ItemFormOutput>({
-    resolver: zodResolver(ItemSchema),
-    mode: "onChange",
-    defaultValues,
-  });
-
-  const descriptionValue = watch("description") ?? "";
-  const quantityValue = watch("quantity") as number | undefined;
-
-  useEffect(() => {
-    if (type === undefined) return;
-
-    if (type === "update" || type === "create") {
-      reset(defaultValues);
-    }
-  }, [defaultValues, reset, type]);
-
-  const clearForm = () => {
-    if (isUpdateMode) {
-      return reset({
-        ...defaultValues,
-        description: defaultValues.description ?? ""
-      });
-    }
-    return reset(DEFAULT_ITEM);
-  };
-
-  useEffect(() => {
-    if (!open && isDirty) {
-      clearForm();
-    }
-  }, [open, isDirty]);
-
-  const onSubmit: SubmitHandler<ItemFormOutput> = async (data) => {
-    // API Call
-    clearForm();
-    setOpen(false);
-    onConfirm &&
-      onConfirm({
-        ...data,
-        quantity: data.quantity ?? 1,
-        purchased: data.purchased ?? false,
-      });
-  };
+  const formKey = useMemo(() => {
+    const idPart = defaultValues?.id ?? "newId";
+    const modePart = type ?? "none";
+    return `${modePart}:${idPart}`;
+  }, [type, defaultValues?.id]);
 
   const openDrawer = (props: GlobalDrawerProps) => {
     setDrawerProps({ ...props });
@@ -125,7 +58,7 @@ const GlobalDrawerProvider: FC<GlobalDrawerProviderProps> = ({ children }) => {
             (e.currentTarget as HTMLElement).focus();
           }}
         >
-          <div className="h-full bg-white">
+          <div className="flex flex-col h-full bg-white">
             <DrawerHeader className="bg-drawerHeaderBg w-full h-16 pl-[30px] border-b-[0.5px] border-drawerBorderGray">
               <div className="w-full h-full flex items-center justify-between">
                 <DrawerTitle className="text-secondaryFont font-dosis">
@@ -141,157 +74,18 @@ const GlobalDrawerProvider: FC<GlobalDrawerProviderProps> = ({ children }) => {
                 </button>
               </div>
             </DrawerHeader>
-            <div className="pl-[30px] pt-7 pr-6">
-              <div className="flex flex-col font-nunito font-normal mb-4">
-                <h2 className="text-lg leading-6 text-primaryFont">
-                  Add an Item
-                </h2>
-                <div className="flex items-center justify-between">
-                  <DrawerDescription
-                    className={cn(
-                      "text-base leading-[22px] text-secondaryFont mt-2",
-                      descriptionTextClassName
-                    )}
-                  >
-                    {description}
-                  </DrawerDescription>
-                  {isDirty && (
-                    <button
-                      onClick={clearForm}
-                      className="font-medium text-xs hover:opacity-80 text-primaryFont"
-                    >
-                      Clear Form
-                    </button>
-                  )}
-                </div>
-              </div>
-              <form
-                id="item-form"
-                className="flex flex-col gap-4"
-                onSubmit={handleSubmit(onSubmit)}
-              >
-                <div>
-                  <Input
-                    id="item-name"
-                    placeholder="Item Name"
-                    {...register("itemName")}
-                  />
-                  {errors.itemName && (
-                    <p className="mt-1 text-sm text-red-600">
-                      {errors.itemName.message}
-                    </p>
-                  )}
-                </div>
-                <div>
-                  <div className="relative h-[140px]">
-                    <Textarea
-                      id="item-description"
-                      placeholder="Description"
-                      {...register("description")}
-                    />
-                    <span
-                      className={cn(
-                        "text-xs absolute bottom-3 right-3",
-                        descriptionValue.length > MAX_DESCRIPTION
-                          ? "text-red-600"
-                          : "text-secondaryFont"
-                      )}
-                      aria-live="polite"
-                    >
-                      {descriptionValue.length}/{MAX_DESCRIPTION}
-                    </span>
-                  </div>
-                  {errors.description && (
-                    <p className="mt-1 text-sm text-red-600">
-                      {errors.description.message}
-                    </p>
-                  )}
-                </div>
-                <div>
-                  <Controller
-                    control={control}
-                    name="quantity"
-                    render={({ field }) => (
-                      <Select
-                        open={selectOpen}
-                        onOpenChange={setSelectOpen}
-                        onClick={(value: number) => {
-                          field.onChange(value);
-                          setSelectOpen(false);
-                        }}
-                        value={quantityValue}
-                      />
-                    )}
-                  />
-                  {errors.quantity && (
-                    <p className="mt-1 text-sm text-red-600">
-                      {errors.quantity.message}
-                    </p>
-                  )}
-                </div>
-                {isUpdateMode && (
-                  <div className="flex items-center justify-between mt-4 z-[1]">
-                    <Controller
-                      control={control}
-                      name="purchased"
-                      render={({ field: { value, onChange, onBlur, ref } }) => (
-                        <div className="flex gap-4 h-6 items-center">
-                          <Checkbox
-                            id="item-purchased"
-                            name="item-purchased"
-                            checked={value}
-                            onCheckedChange={(checked) =>
-                              onChange(Boolean(checked))
-                            }
-                            aria-invalid={!!errors.purchased || undefined}
-                          />
-                          <label
-                            htmlFor="item-purchased"
-                            className={cn(
-                              "text-placeholderGray text-base leading-[22px] font-nunito",
-                              value && "text-primaryFont"
-                            )}
-                          >
-                            Purchased
-                          </label>
-                        </div>
-                      )}
-                    />
-                  </div>
-                )}
-              </form>
-            </div>
+            <ItemForm
+              key={formKey}
+              type={type}
+              description={description}
+              descriptionTextClassName={descriptionTextClassName}
+              defaultValues={defaultValues}
+              onConfirm={onConfirm}
+              onClose={closeDrawer}
+              selectOpen={selectOpen}
+              setSelectOpen={setSelectOpen}
+            />
           </div>
-          <DrawerFooter className="bg-white w-full flex">
-            <div className="flex gap-4 w-full justify-end pr-2 font-nunito mb-1">
-              <DrawerClose asChild>
-                <Button
-                  variant="secondary"
-                  className="h-9 font-normal hover:opacity-80"
-                >
-                  Cancel
-                </Button>
-              </DrawerClose>
-              <Button
-                variant="default"
-                className={cn(
-                  "h-9 font-normal w-[85px]",
-                  isUpdateMode && "w-[100px]"
-                )}
-                form="item-form"
-                type="submit"
-                disabled={isSubmitting || !isValid || (!isDirty && isUpdateMode)}
-              >
-                {isSubmitting
-                  ? isUpdateMode
-                    ? "Updating..."
-                    : "Saving..."
-                  : isUpdateMode
-                  ? "Save Item"
-                  : "Add Task"}
-              </Button>
-            </div>
-          </DrawerFooter>
         </DrawerContent>
       </Drawer>
     </GlobalDrawerContext.Provider>


### PR DESCRIPTION
# What's in this PR
- This PR refactors the Global Drawer to improve maintainability. Separated responsibilities between the drawer provider and its child form (`ItemForm`) while simplifying context usage and key logic.

## Changes
- Separated `ItemForm` from `GlobalDrawerProvider`
- Introduced `formKey` generation to ensure proper re-mounting only when needed
  - Allowed removal of `useEffect`
- Restricted textarea resize